### PR TITLE
Made the handler path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Locally with properties set:
 go install
 $GOPATH/bin/internal-content-api \
 --app-port  "8084" \
+--handler-path "internalcontent" \
 --enriched-content-api-uri "http://localhost:8080/__enriched-content-read-api/enrichedconten \
 --document-store-api-uri "http://localhost:8080/__document-store-api/internalcomponents/" \
 --enriched-content-app-name  "Enriched Content Service" \
@@ -50,6 +51,7 @@ With Docker:
 ```
 docker run -ti  
 --env "APP_PORT=8080" \  
+--env "HANDLER_PATH=internalcontent" \
 --env "ENRICHED_CONTENT_API_URI=http://localhost:8080/__enriched-content-read-api/enrichedcontent/" \  
 --env "DOCUMENT_STORE_API_URI=http://localhost:8080/__document-store-api/internalcomponents/" \  
 --env "ENRICHED_CONTENT_APP_NAME=Enriched Content Service" \  
@@ -74,6 +76,16 @@ The read should return the internal content of an article.
 404 if article with given uuid does not exist.
 
 503 when one of the collaborating mandatory services is inaccessible.
+
+
+In case `handler-path` / `HANDLER_PATH` is set to something else other than `internalcontent`, 
+for example to `internalcontent-preview`, the endpoint will change accordingly to:
+
+/internalcontent-preview/{uuid}
+
+Example in this case will be:
+`curl -v http://localhost:8084/internalcontent-preview/9358ba1e-c07f-11e5-846f-79b0e3d20eaf`
+
 
 ### Admin endpoints
 Healthchecks: [http://localhost:8084/__health](http://localhost:8084/__health)

--- a/app.go
+++ b/app.go
@@ -27,6 +27,12 @@ func main() {
 		Desc:   "Default port for Internal Content API",
 		EnvVar: "APP_PORT",
 	})
+	handlerPath := app.String(cli.StringOpt{
+		Name:   "handler-path",
+		Value:  "internalcontent",
+		Desc:   "Path on which the handler will be mapped",
+		EnvVar: "HANDLER_PATH",
+	})
 	enrichedContentAPIURI := app.String(cli.StringOpt{
 		Name:   "enriched-content-api-uri",
 		Value:  "http://localhost:8080/__enriched-content-read-api/enrichedcontent/",
@@ -103,6 +109,7 @@ func main() {
 		sc := serviceConfig{
 			*serviceName,
 			*appPort,
+			*handlerPath,
 			*enrichedContentAPIURI,
 			*documentStoreAPIURI,
 			*enrichedContentAppName,
@@ -121,7 +128,7 @@ func main() {
 		h := setupServiceHandler(sc, metricsHandler, contentHandler)
 		appLogger.ServiceStartedEvent(*serviceName, sc.asMap())
 		metricsHandler.OutputMetricsIfRequired(*graphiteTCPAddress, *graphitePrefix, *logMetrics)
-		err := http.ListenAndServe(":"+*appPort, h)
+		err := http.ListenAndServe(":" + *appPort, h)
 		if err != nil {
 			logrus.Fatalf("Unable to start server: %v", err)
 		}
@@ -131,7 +138,7 @@ func main() {
 
 func setupServiceHandler(sc serviceConfig, metricsHandler Metrics, contentHandler contentHandler) *mux.Router {
 	r := mux.NewRouter()
-	r.Path("/internalcontent/{uuid}").Handler(handlers.MethodHandler{"GET": oldhttphandlers.HTTPMetricsHandler(metricsHandler.registry,
+	r.Path("/" + sc.handlerPath + "/{uuid}").Handler(handlers.MethodHandler{"GET": oldhttphandlers.HTTPMetricsHandler(metricsHandler.registry,
 		oldhttphandlers.TransactionAwareRequestLoggingHandler(logrus.StandardLogger(), contentHandler))})
 	r.Path(httphandlers.BuildInfoPath).HandlerFunc(httphandlers.BuildInfoHandler)
 	r.Path(httphandlers.PingPath).HandlerFunc(httphandlers.PingHandler)
@@ -143,6 +150,7 @@ func setupServiceHandler(sc serviceConfig, metricsHandler Metrics, contentHandle
 type serviceConfig struct {
 	serviceName                  string
 	appPort                      string
+	handlerPath                  string
 	enrichedContentAPIURI        string
 	documentStoreAPIURI          string
 	enrichedContentAppName       string
@@ -160,6 +168,7 @@ func (sc serviceConfig) asMap() map[string]interface{} {
 	return map[string]interface{}{
 		"service-name":                     sc.serviceName,
 		"service-port":                     sc.appPort,
+		"handler-path":                     sc.handlerPath,
 		"enriched-content-api-uri":         sc.enrichedContentAPIURI,
 		"document-store-api-uri":           sc.documentStoreAPIURI,
 		"enriched-content-app-name":        sc.enrichedContentAppName,

--- a/app.go
+++ b/app.go
@@ -128,7 +128,7 @@ func main() {
 		h := setupServiceHandler(sc, metricsHandler, contentHandler)
 		appLogger.ServiceStartedEvent(*serviceName, sc.asMap())
 		metricsHandler.OutputMetricsIfRequired(*graphiteTCPAddress, *graphitePrefix, *logMetrics)
-		err := http.ListenAndServe(":" + *appPort, h)
+		err := http.ListenAndServe(":"+*appPort, h)
 		if err != nil {
 			logrus.Fatalf("Unable to start server: %v", err)
 		}

--- a/app_test.go
+++ b/app_test.go
@@ -109,6 +109,7 @@ func startInternalContentService() {
 	sc := serviceConfig{
 		"internal-content-api",
 		"8084",
+		"internalcontent",
 		enrichedContentAPIURI,
 		documentStoreAPIURI,
 		"Enriched Content",


### PR DESCRIPTION
Handler path is no longer hardcoded to /internalcontent and can be configured via env var.
In case the path is not specified, it will default to /internalcontent