### PR TITLE
Don't use new API from go 1.7 packages.

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestServeHTTP_CacheControlHeaderIsSet(t *testing.T) {
 	metricsHandler := NewMetrics()
 	contentHandler := contentHandler{&sc, appLogger, &metricsHandler}
 
-	req := httptest.NewRequest("GET", "http://internalcontentapi.ft.com/internalcontent/foobar", nil)
+	req, _ := http.NewRequest("GET", "http://internalcontentapi.ft.com/internalcontent/foobar", nil)
 	w := httptest.NewRecorder()
 	contentHandler.ServeHTTP(w, req)
 


### PR DESCRIPTION
1. It breaks the build in alpine.
2. Upgrading to alpine 3.5 and building it with go 1.7 still fails. It needs further investigation