### PR TITLE
resolved leadImages URLs

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -112,8 +112,12 @@ func (handler contentHandler) ServeHTTP(responseWriter http.ResponseWriter, requ
 		handler.handleErrorEvent(responseWriter, internalComponentsEvent, "Error while parsing the response json")
 		return
 	}
+
 	addInternalComponentsToContent(content, internalComponents)
-	resolveImageURLs(content, handler.serviceConfig.envAPIHost)
+
+	resolveTopperImageURLs(content, handler.serviceConfig.envAPIHost)
+	resolveLeadImageURLs(content, handler.serviceConfig.envAPIHost)
+
 	removeEmptyMapFields(content)
 
 	resultBytes, _ := json.Marshal(content)
@@ -131,7 +135,7 @@ func addInternalComponentsToContent(content map[string]interface{}, internalComp
 	}
 }
 
-func resolveImageURLs(content map[string]interface{}, APIHost string) {
+func resolveTopperImageURLs(content map[string]interface{}, APIHost string) {
 	topper, ok := content["topper"].(map[string]interface{})
 	if !ok {
 		return
@@ -142,6 +146,20 @@ func resolveImageURLs(content map[string]interface{}, APIHost string) {
 	if !ok {
 		return
 	}
+
+	resolveImageURLs(images, APIHost)
+}
+
+func resolveLeadImageURLs(content map[string]interface{}, APIHost string) {
+	leadImages, ok := content["leadImages"].([]interface{})
+	if !ok {
+		return
+	}
+
+	resolveImageURLs(leadImages, APIHost)
+}
+
+func resolveImageURLs(images []interface{}, APIHost string) {
 	for _, img := range images {
 		img, ok := img.(map[string]interface{})
 		if !ok {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestResolveImgURLs(t *testing.T) {
+func TestResolveTopperImgURLs(t *testing.T) {
 	APIHost := "unit-test.ft.com"
 	content := map[string]interface{}{
 		"topper": map[string]interface{}{
@@ -19,10 +19,28 @@ func TestResolveImgURLs(t *testing.T) {
 		},
 	}
 
-	resolveImageURLs(content, APIHost)
+	resolveTopperImageURLs(content, APIHost)
 
 	squareImgID := content["topper"].(map[string]interface{})["images"].([]interface{})[0].(map[string]interface{})["id"]
 	wideImgID := content["topper"].(map[string]interface{})["images"].([]interface{})[1].(map[string]interface{})["id"]
+
+	assert.Equal(t, "http://unit-test.ft.com/content/56aed7e7-485f-303d-9605-b885b86e947e", squareImgID.(string))
+	assert.Equal(t, "http://unit-test.ft.com/content/56aed7e7-485f-303d-9605-b885b86e947f", wideImgID.(string))
+}
+
+func TestResolveLeadImgURLs(t *testing.T) {
+	APIHost := "unit-test.ft.com"
+	content := map[string]interface{}{
+		"leadImages": []interface{}{
+			map[string]interface{}{"id": "56aed7e7-485f-303d-9605-b885b86e947e", "type": "square"},
+			map[string]interface{}{"id": "56aed7e7-485f-303d-9605-b885b86e947f", "type": "wide"},
+		},
+	}
+
+	resolveLeadImageURLs(content, APIHost)
+
+	squareImgID := content["leadImages"].([]interface{})[0].(map[string]interface{})["id"]
+	wideImgID := content["leadImages"].([]interface{})[1].(map[string]interface{})["id"]
 
 	assert.Equal(t, "http://unit-test.ft.com/content/56aed7e7-485f-303d-9605-b885b86e947e", squareImgID.(string))
 	assert.Equal(t, "http://unit-test.ft.com/content/56aed7e7-485f-303d-9605-b885b86e947f", wideImgID.(string))


### PR DESCRIPTION
the image UUIDs from the 'leadImages' component are now also resolved to URLs