### PR TITLE
Add support for expanded lead images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ COPY . /internal-content-api/
 
 RUN apk --update add git go ca-certificates \
   && export GOPATH=/gopath \
-  && REPO_PATH="github.com/Financial-Times/internal-content-api" \
+  && REPO_PATH="github.com/Financial-Times/internal-content-api/" \
   && cd internal-content-api \
-  && BUILDINFO_PACKAGE="github.com/Financial-Times/internal-content-api/buildinfo." \
+  && BUILDINFO_PACKAGE="github.com/Financial-Times/internal-content-api/vendor/github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
   && REPOSITORY="repository=$(git config --get remote.origin.url)" \
@@ -17,7 +17,7 @@ RUN apk --update add git go ca-certificates \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
   && mv * $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
-  && go get -t ./... \
+  && go get -v \
   && go test ./... \
   && go build -ldflags="${LDFLAGS}" \
   && mv internal-content-api /internal-content-api-app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apk --update add git go ca-certificates \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
   && mv * $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
-  && go get -v \
+  && go get -u github.com/kardianos/govendor \
+  && $GOPATH/bin/govendor sync \
   && go test ./... \
   && go build -ldflags="${LDFLAGS}" \
   && mv internal-content-api /internal-content-api-app \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Example
 
 The read should return the internal content of an article (i.e. an aggregation of enriched content plus internal components).
 
+#### Optional Parameters
+`expandImages={boolean}`, default *false*
+
+When `true` all the images in the response(main image, body embedded images, lead images and alternative images) get expanded with the content as content-public-read service was called for that image. This service does not call content-public-read directly, but uses image-resolver which is responsible to get the requested images. When `false` the response contains only the IDs to the images.
+
 404 if article with given uuid does not exist.
 
 503 when one of the collaborating mandatory services is inaccessible.

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
 
 checkout:
   post:
-    - mkdir -p $(dirname ${GO_PROJECT_PATH})
+    - mkdir -p "${PROJECT_PARENT_PATH}"
     - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $GO_PROJECT_PATH
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -14,21 +14,17 @@ dependencies:
   pre:
     - go get -u github.com/kardianos/govendor
   override:
-    - cd $GO_PROJECT_PATH && govendor sync
-    - cd $GO_PROJECT_PATH && go get -t -d -v ./...
-    - cd $GO_PROJECT_PATH && go build -v
+    - cd $PROJECT_PATH && govendor sync
+    - cd $PROJECT_PATH && go build -v
 
 test:
   pre:
     - go get -u github.com/jstemmer/go-junit-report
     - go get -u github.com/mattn/goveralls
+    - cd $PROJECT_PATH && wget https://raw.githubusercontent.com/Financial-Times/cookiecutter-upp-golang/master/coverage.sh && chmod +x coverage.sh
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - cd $GO_PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $GO_PROJECT_PATH && govendor test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/coverage.out +local
-    - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
-    - |
-      echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result
-    - cd $CIRCLE_ARTIFACTS && cat *.out >> overall-coverage.result
+    - cd $PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - cd $PROJECT_PATH && ./coverage.sh
   post:
-    - goveralls -coverprofile=$CIRCLE_ARTIFACTS/overall-coverage.result -service=circle-ci -repotoken=$COVERALLS_TOKEN
+    - goveralls -coverprofile=$CIRCLE_ARTIFACTS/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
-    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${HOME}/.go_project"
     GO_PROJECT_PATH: "${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+    GOPATH: "${HOME}/.go_workspace:${PROJECT_GOPATH}"
 
 checkout:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
 checkout:
   post:
     - mkdir -p "${PROJECT_PARENT_PATH}"
-    - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $GO_PROJECT_PATH
+    - rsync -avC "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   environment:
-    GO_PROJECT_PATH: "${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+    PROJECT_GOPATH: "${HOME}/.go_project"
+    PROJECT_PARENT_PATH: "${PROJECT_GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}"
+    PROJECT_PATH: "${PROJECT_PARENT_PATH}/${CIRCLE_PROJECT_REPONAME}"
     GOPATH: "${HOME}/.go_workspace:${PROJECT_GOPATH}"
 
 checkout:

--- a/handlers.go
+++ b/handlers.go
@@ -8,16 +8,23 @@ import (
 	"net/http"
 	"sync"
 
+	"bytes"
 	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	gouuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
+	"strconv"
 	"strings"
+	"errors"
 )
 
-const uuidKey = "uuid"
-const previewSuffix = "-preview"
+const (
+	previewSuffix              = "-preview"
+	uuidKey         contextKey = "uuid"
+	expandImagesKey contextKey = "expandImages"
+)
+
 var excludedAttributes = map[string]bool{"uuid": true, "lastModified": true, "publishReference": true}
 
 type internalContentHandler struct {
@@ -33,7 +40,7 @@ type ErrorMessage struct {
 type responsePart struct {
 	isOk       bool
 	statusCode int
-	e	   event
+	e          event
 	content    map[string]interface{}
 }
 
@@ -41,6 +48,12 @@ type retriever struct {
 	uri           string
 	sourceAppName string
 	doFail        bool
+}
+
+type contextKey string
+
+func (c contextKey) String() string {
+	return string(c)
 }
 
 func (h internalContentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -56,11 +69,19 @@ func (h internalContentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	tid := transactionidutils.GetTransactionIDFromRequest(r)
 	h.log.TransactionStartedEvent(r.RequestURI, tid, uuid)
+
+	expandImagesParam := r.URL.Query().Get(expandImagesKey.String())
+	expandImages, err := strconv.ParseBool(expandImagesParam)
+	if err != nil {
+		expandImages = false
+	}
+
 	ctx := context.WithValue(transactionidutils.TransactionAwareContext(context.Background(), tid), uuidKey, uuid)
+	ctx = context.WithValue(ctx, expandImagesKey, expandImages)
 
 	retrievers := []retriever{
 		{h.serviceConfig.contentSourceURI, h.serviceConfig.contentSourceAppName, true},
-		{h.serviceConfig.internalComponentsSourceURI, h.serviceConfig.internalComponentsSourceAppName, false },
+		{h.serviceConfig.internalComponentsSourceURI, h.serviceConfig.internalComponentsSourceAppName, false},
 	}
 	parts := h.asyncRetrievalsAndUnmarshalls(ctx, retrievers, uuid, tid)
 	for _, p := range parts {
@@ -74,7 +95,10 @@ func (h internalContentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			return
 		}
 	}
-	mergedContent := h.resolveAdditionalFields(parts, uuid)
+
+	mergedContent := mergeParts(parts)
+	mergedContent = h.resolveLeadImages(mergedContent, h.serviceConfig.envAPIHost, uuid, ctx, expandImages)
+	mergedContent = h.resolveAdditionalFields(mergedContent, uuid, expandImages)
 
 	resultBytes, _ := json.Marshal(mergedContent)
 	w.Header().Set("Cache-Control", h.serviceConfig.cacheControlPolicy)
@@ -117,18 +141,16 @@ func (h internalContentHandler) retrieveAndUnmarshall(ctx context.Context, r ret
 	defer cleanupResp(resp, h.log.log)
 
 	part.e = event{
-		serviceName: r.sourceAppName,
-		requestURL: extractRequestURL(resp),
+		serviceName:   r.sourceAppName,
+		requestURL:    extractRequestURL(resp),
 		transactionID: tid,
-		uuid: uuid,
+		uuid:          uuid,
 	}
 	part.content, part.e.err = unmarshallToMap(resp)
 	return part
 }
 
-func (h internalContentHandler) resolveAdditionalFields(parts []responsePart, uuid string) map[string]interface{} {
-	mergedContent := mergeParts(parts)
-	resolveLeadImageURLs(mergedContent, h.serviceConfig.envAPIHost)
+func (h internalContentHandler) resolveAdditionalFields(mergedContent map[string]interface{}, uuid string, expandImages bool) map[string]interface{} {
 	resolveRequestUrl(mergedContent, h, uuid)
 	resolveApiUrl(mergedContent, h, uuid)
 	removeEmptyMapFields(mergedContent)
@@ -149,10 +171,10 @@ func mergeParts(parts []responsePart) map[string]interface{} {
 	return content
 }
 
-func resolveLeadImageURLs(content map[string]interface{}, APIHost string) {
+func (h internalContentHandler) resolveLeadImages(content map[string]interface{}, APIHost string, uuid string, ctx context.Context, expandImages bool) map[string]interface{} {
 	leadImages, ok := content["leadImages"].([]interface{})
 	if !ok {
-		return
+		return content
 	}
 
 	for _, img := range leadImages {
@@ -163,6 +185,101 @@ func resolveLeadImageURLs(content map[string]interface{}, APIHost string) {
 		imgURL := "http://" + APIHost + "/content/" + img["id"].(string)
 		img["id"] = imgURL
 	}
+
+	transformedContent := make(map[string]interface{})
+	for k, v := range content {
+		transformedContent[k] = v
+	}
+
+	if expandImages {
+		var err error
+		transformedContent, err = h.getExpandedImages(uuid, ctx, content)
+		if err != nil {
+			transactionID, _ := transactionidutils.GetTransactionIDFromContext(ctx)
+			h.handleError(err, h.serviceConfig.imageResolverAppName, h.serviceConfig.imageResolverSourceURI, transactionID, uuid)
+			return content
+		}
+	}
+	return transformedContent
+}
+
+func (h internalContentHandler) getExpandedImages(uuid string, ctx context.Context, content map[string]interface{}) (map[string]interface{}, error) {
+	var expandedContent map[string]interface{}
+	transactionID, err := transactionidutils.GetTransactionIDFromContext(ctx)
+	if err != nil {
+		transactionID = transactionidutils.NewTransactionID()
+	}
+	body, err := json.Marshal(content)
+	if err != nil {
+		return expandedContent, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, h.serviceConfig.imageResolverSourceURI, bytes.NewReader(body))
+	if err != nil {
+		return expandedContent, err
+	}
+	req.Header.Set(transactionidutils.TransactionIDHeader, transactionID)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.serviceConfig.httpClient.Do(req)
+	if err != nil {
+		return expandedContent, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		h.log.RequestFailedEvent(h.serviceConfig.imageResolverAppName, req.URL.String(), resp, uuid)
+		h.metrics.recordRequestFailedEvent()
+		errMsg := fmt.Sprintf("Received status code %d from %v.", resp.StatusCode, h.serviceConfig.imageResolverAppName)
+		return expandedContent, errors.New(errMsg)
+	}
+	h.log.ResponseEvent(h.serviceConfig.imageResolverAppName, req.URL.String(), resp, uuid)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return expandedContent, err
+	}
+
+	err = json.Unmarshal(body, &expandedContent)
+	if err != nil {
+		return expandedContent, err
+	}
+
+	leadImages, found := expandedContent["leadImages"]
+	if !found {
+		return expandedContent, errors.New("Cannot find leadImages in response.")
+	}
+
+	leadImagesAsArray := (leadImages).([]interface{})
+	for i := 0; i < len(leadImagesAsArray); i++ {
+		leadImageAsMap := leadImagesAsArray[i].(map[string]interface{})
+		transformLeadImage(leadImageAsMap)
+	}
+	return expandedContent, nil
+}
+
+func transformLeadImage(leadImage map[string]interface{}) {
+	imageModel, found := leadImage["image"]
+	if !found {
+		//if image field is not found inside the image, continue the processing
+		return
+	}
+
+	var apiURL interface{}
+	imageModelAsMap := imageModel.(map[string]interface{})
+	if apiURL, found = imageModelAsMap["requestUrl"]; !found {
+		if apiURL, found = leadImage["id"]; !found {
+			return
+		}
+	}
+
+	apiURLAsString, ok := apiURL.(string)
+	if !ok {
+		return
+	}
+	imageModelAsMap["id"] = apiURLAsString
+	imageModelAsMap["apiUrl"] = apiURLAsString
+	delete(imageModelAsMap, "requestUrl")
 }
 
 func resolveRequestUrl(content map[string]interface{}, handler internalContentHandler, contentUUID string) {
@@ -193,13 +310,20 @@ func (h internalContentHandler) callService(ctx context.Context, r retriever) (r
 	transactionID, _ := transactionidutils.GetTransactionIDFromContext(ctx)
 	h.log.RequestEvent(r.sourceAppName, requestURL, transactionID, uuid)
 
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		h.handleError(err, r.sourceAppName, requestURL, req.Header.Get(transactionidutils.TransactionIDHeader), uuid)
 		return responsePart{isOk: false, statusCode: http.StatusInternalServerError}, nil
 	}
 	req.Header.Set(transactionidutils.TransactionIDHeader, transactionID)
 	req.Header.Set("Content-Type", "application/json")
+
+	expandImages, ok := ctx.Value(expandImagesKey).(bool)
+	if ok && r.sourceAppName == h.serviceConfig.contentSourceAppName {
+		q := req.URL.Query()
+		q.Add(expandImagesKey.String(), strconv.FormatBool(expandImages))
+		req.URL.RawQuery = q.Encode()
+	}
 
 	resp, err := h.serviceConfig.httpClient.Do(req)
 	//this happens when hostname cannot be resolved or host is not accessible

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"golang.org/x/net/context"
 )
 
 func TestResolveLeadImgURLs(t *testing.T) {
@@ -14,10 +15,11 @@ func TestResolveLeadImgURLs(t *testing.T) {
 		},
 	}
 
-	resolveLeadImageURLs(content, APIHost)
+	h := internalContentHandler{}
+	actual := h.resolveLeadImages(content, APIHost, "4deb3541-d455-3a39-a51f-ebd94095aa98", context.Background(), false)
 
-	squareImgID := content["leadImages"].([]interface{})[0].(map[string]interface{})["id"]
-	wideImgID := content["leadImages"].([]interface{})[1].(map[string]interface{})["id"]
+	squareImgID := actual["leadImages"].([]interface{})[0].(map[string]interface{})["id"]
+	wideImgID := actual["leadImages"].([]interface{})[1].(map[string]interface{})["id"]
 
 	assert.Equal(t, "http://unit-test.ft.com/content/56aed7e7-485f-303d-9605-b885b86e947e", squareImgID.(string))
 	assert.Equal(t, "http://unit-test.ft.com/content/56aed7e7-485f-303d-9605-b885b86e947f", wideImgID.(string))

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/Financial-Times/transactionid-utils-go"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
 func TestResolveLeadImgURLs(t *testing.T) {
-	APIHost := "unit-test.ft.com"
 	content := map[string]interface{}{
 		"leadImages": []interface{}{
 			map[string]interface{}{"id": "56aed7e7-485f-303d-9605-b885b86e947e", "type": "square"},
@@ -15,8 +16,16 @@ func TestResolveLeadImgURLs(t *testing.T) {
 		},
 	}
 
-	h := internalContentHandler{}
-	actual := h.resolveLeadImages(content, APIHost, "4deb3541-d455-3a39-a51f-ebd94095aa98", context.Background(), false)
+	h := internalContentHandler{
+		serviceConfig: &serviceConfig{envAPIHost: "unit-test.ft.com"},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, transactionidutils.TransactionIDKey, "sample_tid")
+	ctx = context.WithValue(ctx, uuidKey, "4deb3541-d455-3a39-a51f-ebd94095aa98")
+	ctx = context.WithValue(ctx, expandImagesKey, false)
+
+	actual := resolveLeadImages(ctx, content, h)
 
 	squareImgID := actual["leadImages"].([]interface{})[0].(map[string]interface{})["id"]
 	wideImgID := actual["leadImages"].([]interface{})[1].(map[string]interface{})["id"]

--- a/healthchecks.go
+++ b/healthchecks.go
@@ -19,6 +19,11 @@ func (sc *serviceConfig) gtgCheck() gtg.Status {
 		return gtg.Status{GoodToGo: false, Message: msg}
 	}
 
+	msg, err = sc.checkServiceAvailability(sc.imageResolverAppName, sc.imageResolverAppHealthURI)
+	if err != nil {
+		return gtg.Status{GoodToGo: false, Message: msg}
+	}
+
 	return gtg.Status{GoodToGo: true}
 }
 
@@ -44,6 +49,19 @@ func (sc *serviceConfig) internalComponentsSourceAppCheck() fthealth.Check {
 		TechnicalSummary: "Checks that " + sc.internalComponentsSourceAppName + " is reachable. " + sc.appName + " relies on " + sc.internalComponentsSourceAppName + " to get the internal components",
 		Checker: func() (string, error) {
 			return sc.checkServiceAvailability(sc.internalComponentsSourceAppName, sc.internalComponentsSourceAppHealthURI)
+		},
+	}
+}
+
+func (sc *serviceConfig) imageResolverAppCheck() fthealth.Check {
+	return fthealth.Check{
+		BusinessImpact:   sc.imageResolverAppBusinessImpact,
+		Name:             sc.imageResolverAppName,
+		PanicGuide:       sc.imageResolverAppPanicGuide,
+		Severity:         2,
+		TechnicalSummary: "Checks that " + sc.imageResolverAppName + " is reachable. " + sc.appName + " relies on " + sc.imageResolverAppName + " to get the expanded images",
+		Checker: func() (string, error) {
+			return sc.checkServiceAvailability(sc.imageResolverAppName, sc.imageResolverAppHealthURI)
 		},
 	}
 }

--- a/test-resources/document-store-api-output.json
+++ b/test-resources/document-store-api-output.json
@@ -8,21 +8,15 @@
   "leadImages": [
     {
       "id": "f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
-      "type": "square",
-      "width": 90,
-      "height": 90
+      "type": "square"
     },
     {
       "id": "35059e34-dc33-11e6-86ac-f253db7791c6",
-      "type": "standard",
-      "width": 90,
-      "height": 160
+      "type": "standard"
     },
     {
       "id": "c374c260-dd84-11e6-9d7c-be108f1c1dce",
-      "type": "wide",
-      "width": 77,
-      "height": 180
+      "type": "wide"
     }
   ],
   "uuid": "5c3cae78-dbef-11e6-9d7c-be108f1c1dce"

--- a/test-resources/full-expanded-internal-content-api-output.json
+++ b/test-resources/full-expanded-internal-content-api-output.json
@@ -1,0 +1,128 @@
+{
+  "annotations": [
+    {
+      "apiUrl": "http://api.ft.com/brands/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54",
+      "directType": "http://www.ft.com/ontology/product/Brand",
+      "id": "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Financial Times",
+      "type": "BRAND",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/classification/Classification",
+        "http://www.ft.com/ontology/product/Brand"
+      ]
+    }
+  ],
+  "apiUrl": "http://api.ft.com/internalcontent/5c3cae78-dbef-11e6-9d7c-be108f1c1dce",
+  "bodyXML": "<body><ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/6299d4b0-d110-11e6-2e0d-ff9693c01f89\" data-embedded=\"true\"></ft-content><p>Pellentesque a ante ac nisl porttitor placerat id ac arcu. Phasellus sit amet felis quis velit sollicitudin pellentesque ac ut dui. Ut sit amet dolor vel risus imperdiet placerat at non nisi.</p>\n<p>Pellentesque a ante ac nisl porttitor placerat id ac arcu. Phasellus sit amet felis quis velit sollicitudin pellentesque ac ut dui. Ut sit amet dolor vel risus imperdiet placerat at non nisi.</p>\n</body>",
+  "brands": [
+    "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+  ],
+  "byline": "By ",
+  "canBeSyndicated": "yes",
+  "comments": {
+    "enabled": true
+  },
+  "id": "http://www.ft.com/thing/5c3cae78-dbef-11e6-9d7c-be108f1c1dce",
+  "identifiers": [
+    {
+      "authority": "http://api.ft.com/system/FTCOM-METHODE",
+      "identifierValue": "5c3cae78-dbef-11e6-9d7c-be108f1c1dce"
+    }
+  ],
+  "lastModified": "2017-01-23T11:09:38.723Z",
+  "leadImages": [
+    {
+      "id": "http://api.ft.com/content/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+      "image": {
+        "apiUrl": "http://api.ft.com/content/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+        "binaryUrl": "http://com.ft.imagepublish.prod-us.s3.amazonaws.com/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+        "id": "http://api.ft.com/content/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7"
+          }
+        ],
+        "lastModified": "2017-01-18T13:51:28.937Z",
+        "pixelHeight": 2000,
+        "pixelWidth": 2000,
+        "publishReference": "tid_q28ejle8pa",
+        "publishedDate": "2017-01-18T13:51:00.000Z",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      },
+      "type": "square"
+    },
+    {
+      "id": "http://api.ft.com/content/35059e34-dc33-11e6-86ac-f253db7791c6",
+      "image": {
+        "apiUrl": "http://api.ft.com/content/35059e34-dc33-11e6-86ac-f253db7791c6",
+        "binaryUrl": "http://com.ft.imagepublish.prod-us.s3.amazonaws.com/35059e34-dc33-11e6-86ac-f253db7791c6",
+        "copyright": {
+          "notice": "© FT montage; Bloomberg"
+        },
+        "id": "http://api.ft.com/content/35059e34-dc33-11e6-86ac-f253db7791c6",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "35059e34-dc33-11e6-86ac-f253db7791c6"
+          }
+        ],
+        "lastModified": "2017-01-16T21:57:36.648Z",
+        "pixelHeight": 1152,
+        "pixelWidth": 2048,
+        "publishReference": "tid_e5b5wextjx",
+        "publishedDate": "2017-01-16T21:57:00.000Z",
+        "title": "Larry Fink",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      },
+      "type": "standard"
+    },
+    {
+      "id": "http://api.ft.com/content/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+      "image": {
+        "apiUrl": "http://api.ft.com/content/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+        "binaryUrl": "http://com.ft.imagepublish.prod-us.s3.amazonaws.com/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+        "id": "http://api.ft.com/content/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "c374c260-dd84-11e6-9d7c-be108f1c1dce"
+          }
+        ],
+        "lastModified": "2017-01-18T13:51:29.113Z",
+        "pixelHeight": 1000,
+        "pixelWidth": 2350,
+        "publishReference": "tid_kibxeork42",
+        "publishedDate": "2017-01-18T13:51:00.000Z",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      },
+      "type": "wide"
+    }
+  ],
+  "mainImage": {
+    "id": "http://api.ft.com/content/6299d4b0-d110-11e6-2e0d-ff9693c01f89"
+  },
+  "prefLabel": "Lorem ipsum dolor sit amet",
+  "publishReference": "tid_9h0oph0oil",
+  "publishedDate": "2014-01-29T12:39:06.000Z",
+  "requestUrl": "http://api.ft.com/internalcontent/5c3cae78-dbef-11e6-9d7c-be108f1c1dce",
+  "standfirst": "Curabitur accumsan elit luctus nunc condimentum",
+  "standout": {
+    "editorsChoice": false,
+    "exclusive": false,
+    "scoop": false
+  },
+  "title": "Lorem ipsum dolor sit amet",
+  "topper": {
+    "bgColor": "black",
+    "headline": "Topper headline",
+    "standfirst": "Topper standfirst",
+    "theme": "split-text-left"
+  },
+  "types": [
+    "http://www.ft.com/ontology/content/Article"
+  ]
+}

--- a/test-resources/full-internal-content-api-output.json
+++ b/test-resources/full-internal-content-api-output.json
@@ -55,22 +55,16 @@
   },
   "leadImages": [
     {
-      "height": 90,
       "id": "http://api.ft.com/content/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
-      "type": "square",
-      "width": 90
+      "type": "square"
     },
     {
-      "height": 160,
       "id": "http://api.ft.com/content/35059e34-dc33-11e6-86ac-f253db7791c6",
-      "type": "standard",
-      "width": 90
+      "type": "standard"
     },
     {
-      "height": 180,
       "id": "http://api.ft.com/content/c374c260-dd84-11e6-9d7c-be108f1c1dce",
-      "type": "wide",
-      "width": 77
+      "type": "wide"
     }
   ],
   "types": [

--- a/test-resources/image-resolver-output.json
+++ b/test-resources/image-resolver-output.json
@@ -1,0 +1,142 @@
+{
+  "annotations": [
+    {
+      "apiUrl": "http://api.ft.com/brands/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54",
+      "directType": "http://www.ft.com/ontology/product/Brand",
+      "id": "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Financial Times",
+      "type": "BRAND",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/classification/Classification",
+        "http://www.ft.com/ontology/product/Brand"
+      ]
+    }
+  ],
+  "apiUrl": "http://api.ft.com/internalcontent/5c3cae78-dbef-11e6-9d7c-be108f1c1dce",
+  "bodyXML": "<body><ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/6299d4b0-d110-11e6-2e0d-ff9693c01f89\" data-embedded=\"true\"></ft-content><p>Pellentesque a ante ac nisl porttitor placerat id ac arcu. Phasellus sit amet felis quis velit sollicitudin pellentesque ac ut dui. Ut sit amet dolor vel risus imperdiet placerat at non nisi.</p>\n<p>Pellentesque a ante ac nisl porttitor placerat id ac arcu. Phasellus sit amet felis quis velit sollicitudin pellentesque ac ut dui. Ut sit amet dolor vel risus imperdiet placerat at non nisi.</p>\n</body>",
+  "brands": [
+    "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+  ],
+  "byline": "By ",
+  "canBeSyndicated": "yes",
+  "comments": {
+    "enabled": true
+  },
+  "id": "http://www.ft.com/thing/5c3cae78-dbef-11e6-9d7c-be108f1c1dce",
+  "identifiers": [
+    {
+      "authority": "http://api.ft.com/system/FTCOM-METHODE",
+      "identifierValue": "5c3cae78-dbef-11e6-9d7c-be108f1c1dce"
+    }
+  ],
+  "lastModified": "2017-01-23T11:09:38.723Z",
+  "leadImages": [
+    {
+      "id": "http://api.ft.com/content/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+      "image": {
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "binaryUrl": "http://com.ft.imagepublish.prod-us.s3.amazonaws.com/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+        "description": "",
+        "id": "http://www.ft.com/thing/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7"
+          }
+        ],
+        "lastModified": "2017-01-18T13:51:28.937Z",
+        "pixelHeight": 2000,
+        "pixelWidth": 2000,
+        "publishReference": "tid_q28ejle8pa",
+        "publishedDate": "2017-01-18T13:51:00.000Z",
+        "requestUrl": "http://api.ft.com/content/f3add2e0-dbfa-11e6-a7d5-ce30ecef69c7",
+        "title": "",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      },
+      "type": "square"
+    },
+    {
+      "id": "http://api.ft.com/content/35059e34-dc33-11e6-86ac-f253db7791c6",
+      "image": {
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "binaryUrl": "http://com.ft.imagepublish.prod-us.s3.amazonaws.com/35059e34-dc33-11e6-86ac-f253db7791c6",
+        "copyright": {
+          "notice": "© FT montage; Bloomberg"
+        },
+        "description": "",
+        "id": "http://www.ft.com/thing/35059e34-dc33-11e6-86ac-f253db7791c6",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "35059e34-dc33-11e6-86ac-f253db7791c6"
+          }
+        ],
+        "lastModified": "2017-01-16T21:57:36.648Z",
+        "pixelHeight": 1152,
+        "pixelWidth": 2048,
+        "publishReference": "tid_e5b5wextjx",
+        "publishedDate": "2017-01-16T21:57:00.000Z",
+        "requestUrl": "http://api.ft.com/content/35059e34-dc33-11e6-86ac-f253db7791c6",
+        "title": "Larry Fink",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      },
+      "type": "standard"
+    },
+    {
+      "id": "http://api.ft.com/content/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+      "image": {
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "binaryUrl": "http://com.ft.imagepublish.prod-us.s3.amazonaws.com/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+        "description": "",
+        "id": "http://www.ft.com/thing/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "c374c260-dd84-11e6-9d7c-be108f1c1dce"
+          }
+        ],
+        "lastModified": "2017-01-18T13:51:29.113Z",
+        "pixelHeight": 1000,
+        "pixelWidth": 2350,
+        "publishReference": "tid_kibxeork42",
+        "publishedDate": "2017-01-18T13:51:00.000Z",
+        "requestUrl": "http://api.ft.com/content/c374c260-dd84-11e6-9d7c-be108f1c1dce",
+        "title": "",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      },
+      "type": "wide"
+    }
+  ],
+  "mainImage": {
+    "id": "http://api.ft.com/content/6299d4b0-d110-11e6-2e0d-ff9693c01f89"
+  },
+  "prefLabel": "Lorem ipsum dolor sit amet",
+  "publishReference": "tid_9h0oph0oil",
+  "publishedDate": "2014-01-29T12:39:06.000Z",
+  "requestUrl": "http://api.ft.com/internalcontent/5c3cae78-dbef-11e6-9d7c-be108f1c1dce",
+  "standfirst": "Curabitur accumsan elit luctus nunc condimentum",
+  "standout": {
+    "editorsChoice": false,
+    "exclusive": false,
+    "scoop": false
+  },
+  "title": "Lorem ipsum dolor sit amet",
+  "topper": {
+    "bgColor": "black",
+    "headline": "Topper headline",
+    "standfirst": "Topper standfirst",
+    "theme": "split-text-left"
+  },
+  "types": [
+    "http://www.ft.com/ontology/content/Article"
+  ]
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "ddLGmQTKn5BeEsKYFOGAH33sEfg=",
+			"checksumSHA1": "9U6PDZJipzGOWukYCqT+rKmzapo=",
 			"path": "github.com/Financial-Times/transactionid-utils-go",
-			"revision": "a2b1163e7c2f6c77add74ca2c7fc7422323a2d78",
-			"revisionTime": "2016-02-12T16:38:35Z"
+			"revision": "df2f00c734957c9dd651ce23ab0e0902504c7636",
+			"revisionTime": "2017-03-28T16:39:54Z"
 		},
 		{
 			"checksumSHA1": "ZKxETlJdB2XubMrZnXB0FQimVA8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -95,6 +95,12 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
+			"checksumSHA1": "HUXE+Nrcau8FSaVEvPYHMvDjxOE=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "b061729afc07e77a8aa4fad0a2fd840958f1942a",
+			"revisionTime": "2016-09-27T10:08:44Z"
+		},
+		{
 			"checksumSHA1": "JXUVA1jky8ZX8w09p2t5KLs97Nc=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -58,6 +58,12 @@
 			"revisionTime": "2017-01-30T11:31:45Z"
 		},
 		{
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
+			"path": "github.com/gorilla/context",
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
+		},
+		{
 			"checksumSHA1": "I+GdpjQMP4tAYwF4CAklylRWeYI=",
 			"path": "github.com/gorilla/handlers",
 			"revision": "3a5767ca75ece5f7f1440b1d16975247f8d8b221",


### PR DESCRIPTION
In order to return expanded lead images, internal-content-api has to make a POST request to image-resolver which will return the entire content together with expanded images if no error occurs. If an error occurs, it should return the content without expanded lead images