### PR TITLE
Use separate affinity rules for EU and US

### DIFF
--- a/helm/internal-content-api/app-configs/internal-content-api_eks_delivery_prod_us.yaml
+++ b/helm/internal-content-api/app-configs/internal-content-api_eks_delivery_prod_us.yaml
@@ -23,23 +23,11 @@ env:
   APP_SYSTEM_CODE: "up-ica"
 
 affinity:
-  podAntiAffinity:
+  nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
+      nodeSelectorTerms:
+      - matchExpressions:
+          - key: topology.kubernetes.io/zone
             operator: In
             values:
-            - internal-content-api
-        topologyKey: "kubernetes.io/hostname"
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - wight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - content-search-api-port
-        topologyKey: "kubernetes.io/hostname"
-
+              - us-east-1a

--- a/helm/internal-content-api/app-configs/internal-content-api_eks_delivery_staging_us.yaml
+++ b/helm/internal-content-api/app-configs/internal-content-api_eks_delivery_staging_us.yaml
@@ -23,23 +23,11 @@ env:
   APP_SYSTEM_CODE: "up-ica"
 
 affinity:
-  podAntiAffinity:
+  nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
+      nodeSelectorTerms:
+      - matchExpressions:
+          - key: topology.kubernetes.io/zone
             operator: In
             values:
-            - internal-content-api
-        topologyKey: "kubernetes.io/hostname"
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - wight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - content-search-api-port
-        topologyKey: "kubernetes.io/hostname"
-
+              - us-east-1a

--- a/helm/internal-content-api/templates/deployment.yaml
+++ b/helm/internal-content-api/templates/deployment.yaml
@@ -18,26 +18,8 @@ spec:
         app: {{ .Values.service.name }}
         visualize: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ .Values.service.name }}
-            topologyKey: "kubernetes.io/hostname"
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - content-search-api-port
-              topologyKey: "kubernetes.io/hostname"
+      affinity:        
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: {{ .Values.service.name }}
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"


### PR DESCRIPTION
# Description

## Why

To test if the latency is going to improve if we place `internal-content-api`, `enriched-content-read-api`, `content-public-read`, `document-store-api`, and `content-unroller` in the same AZ in US.

## Anything, in particular, you'd like to highlight to reviewers

_I left the affinity rules for EU just like they were._ 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
